### PR TITLE
EC-32 feat(routing): add navigation between login and sign up pages

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -35,7 +35,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forRoot(routes, { bindToComponentInputs: true })],
   exports: [RouterModule],
 })
 export class AppRoutingModule {}

--- a/src/app/auth/pages/sign-in/sign-in.component.html
+++ b/src/app/auth/pages/sign-in/sign-in.component.html
@@ -1,3 +1,6 @@
 <div class="wrapper">
   <ec-sign-in-form></ec-sign-in-form>
+  <button class="sign-up-button" tuiButton type="button" (click)="toSignUp()">
+    Create your VogueGPT account
+  </button>
 </div>

--- a/src/app/auth/pages/sign-in/sign-in.component.scss
+++ b/src/app/auth/pages/sign-in/sign-in.component.scss
@@ -1,7 +1,20 @@
 :host {
   .wrapper {
+    display: flex;
+    flex-direction: column;
+
     width: 580px;
     margin: 0 auto;
     padding: 0 40px;
+  }
+
+  ::ng-deep form {
+    margin-bottom: 100px;
+  }
+
+  .sign-up-button {
+    align-self: center;
+    max-width: fit-content;
+    padding: 5px 36px;
   }
 }

--- a/src/app/auth/pages/sign-in/sign-in.component.ts
+++ b/src/app/auth/pages/sign-in/sign-in.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'ec-sign-in',
@@ -6,4 +7,10 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   styleUrls: ['./sign-in.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SignInComponent {}
+export class SignInComponent {
+  constructor(private readonly route: ActivatedRoute, private readonly router: Router) {}
+
+  public toSignUp(): void {
+    this.router.navigate(['sign-up'], { relativeTo: this.route.parent });
+  }
+}

--- a/src/app/auth/pages/sign-up/sign-up.component.html
+++ b/src/app/auth/pages/sign-up/sign-up.component.html
@@ -1,3 +1,7 @@
 <div class="wrapper">
   <ec-sign-up-form></ec-sign-up-form>
+  <h3 class="link">
+    <span>Alredy have an account? </span
+    ><a tuiLink routerLink="../sign-in">Click here to sign in</a>
+  </h3>
 </div>

--- a/src/app/auth/pages/sign-up/sign-up.component.scss
+++ b/src/app/auth/pages/sign-up/sign-up.component.scss
@@ -4,4 +4,8 @@
     margin: 0 auto;
     padding: 0 40px;
   }
+
+  .link {
+    text-align: center;
+  }
 }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -7,6 +7,7 @@ import {
   TuiButtonModule,
   TuiDataListModule,
   TuiErrorModule,
+  TuiLinkModule,
   TuiNotificationModule,
 } from '@taiga-ui/core';
 import {
@@ -42,6 +43,7 @@ import { PasswordInputComponent } from './components/password-input/password-inp
     TuiDataListWrapperModule,
     TuiFilterByInputPipeModule,
     TuiCheckboxLabeledModule,
+    TuiLinkModule,
     TuiToggleModule,
     MaskitoModule,
   ],
@@ -64,6 +66,7 @@ import { PasswordInputComponent } from './components/password-input/password-inp
     TuiFilterByInputPipeModule,
     TuiCheckboxLabeledModule,
     TuiToggleModule,
+    TuiLinkModule,
     MaskitoModule,
   ],
 })


### PR DESCRIPTION
1. Task: [link](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%232.md)
2. Task in Jira: [link](https://aliaksei-h9.atlassian.net/browse/EC-32)
3. Screenshot:
![auth_sign-up](https://github.com/GPTteam-RS-2023Q1/eCommerceApp/assets/116164343/6958568a-2161-4f2a-b95e-59370b71f86e)
5. Done 20.08.2023 / deadline 21.08.2023
6. Score: 5 / 5

- [x] Add a button or link on the registration page that allows users to navigate to the login page.. (5/5)
